### PR TITLE
fix: support preceding comments

### DIFF
--- a/src/languages/ast-utils.ts
+++ b/src/languages/ast-utils.ts
@@ -1,4 +1,12 @@
-import {type Document, type CST, isPair, isNode} from 'yaml';
+import {
+  type Document,
+  type CST,
+  isPair,
+  isNode,
+  isMap,
+  isSeq,
+  isDocument
+} from 'yaml';
 import type {NodeLike} from './types.js';
 
 export function getNodeToken(
@@ -110,6 +118,40 @@ export function getSiblingTokenFromMap(
   return current;
 }
 
+function visitFirstChild(
+  node: NodeLike,
+  visitor: (node: NodeLike, path: NodeLike[]) => unknown,
+  path: NodeLike[] = []
+) {
+  if (visitor(node, path) === false) {
+    return;
+  }
+
+  if (isDocument(node) && node.contents) {
+    visitFirstChild(node.contents, visitor, [...path, node]);
+    return;
+  }
+
+  if ((isMap(node) || isSeq(node)) && node.items.length > 0) {
+    const firstChild = node.items[0];
+    if (isNode(firstChild) || isPair(firstChild)) {
+      visitFirstChild(firstChild, visitor, [...path, node]);
+    }
+    return;
+  }
+
+  if (isPair(node)) {
+    if (node.key) {
+      if (isNode(node.key)) {
+        visitFirstChild(node.key, visitor, [...path, node]);
+      }
+    } else if (node.value && isNode(node.value)) {
+      visitFirstChild(node.value, visitor, [...path, node]);
+    }
+    return;
+  }
+}
+
 export function processTokens(ast: Document): {
   tokenPrev: WeakMap<CST.Token, CST.Token>;
   tokenNext: WeakMap<CST.Token, CST.Token>;
@@ -145,6 +187,25 @@ export function processTokens(ast: Document): {
     if (firstToken && middleToken) {
       tokenPrev.set(middleToken, firstToken);
     }
+
+    const firstComment = comments[0];
+
+    // Serious hacks because the parser decided to throw away preceding
+    // comments. One day when yaml#637 is fixed, we should be able to remove
+    // this questionable workaround.
+    visitFirstChild(ast, (node) => {
+      if (isNode(node) && node.commentBefore && node.range) {
+        if (firstComment === undefined || node.range[0] < firstComment.offset) {
+          comments.unshift({
+            type: 'comment',
+            offset: Math.max(0, node.range[0] - node.commentBefore.length - 1),
+            indent: 0,
+            source: `#${node.commentBefore}`
+          });
+          return false;
+        }
+      }
+    });
   }
 
   return {

--- a/test/languages/yaml-source-code_test.ts
+++ b/test/languages/yaml-source-code_test.ts
@@ -21,11 +21,12 @@ function getSourceCodeForText(text: string): YAMLSourceCode {
 }
 
 describe('YAMLSourceCode', () => {
-  it('should extract comments on non-documents', () => {
+  it('should extract comments', () => {
     const sourceCode = getSourceCodeForText(
       '# Comment 1\nfoo: bar # Comment 2\nbaz:\n  # Comment 3\n  - boop\n'
     );
     expect(sourceCode.comments).toEqual([
+      {type: 'comment', indent: 0, offset: 1, source: '# Comment 1'},
       {type: 'comment', indent: 2, offset: 40, source: '# Comment 3'},
       {type: 'comment', indent: 0, offset: 21, source: '# Comment 2'}
     ]);
@@ -39,16 +40,18 @@ describe('YAMLSourceCode', () => {
   describe('getInlineConfigNodes', () => {
     it('should get all the inline config nodes', () => {
       const sourceCode = getSourceCodeForText(`
+# eslint someRule: "foo"
 foo: 303 # eslint-disable-line foo
 # eslint-disable-next-line some-rule
 bar: 808 # not a config node
       `);
       const inlineConfigNodes = sourceCode.getInlineConfigNodes();
-      expect(inlineConfigNodes).toHaveLength(2);
-      expect(inlineConfigNodes[0].source).toBe(
+      expect(inlineConfigNodes).toHaveLength(3);
+      expect(inlineConfigNodes[0].source).toBe('# eslint someRule: "foo"');
+      expect(inlineConfigNodes[1].source).toBe(
         '# eslint-disable-next-line some-rule'
       );
-      expect(inlineConfigNodes[1].source).toBe('# eslint-disable-line foo');
+      expect(inlineConfigNodes[2].source).toBe('# eslint-disable-line foo');
     });
   });
 


### PR DESCRIPTION
The parser currently fails to provide preceding tokens (i.e. start of
document). This is a workaround until the `yaml` library fixes it
themselves.
