### PR TITLE
feat: use CST directly

### DIFF
--- a/src/languages/types.ts
+++ b/src/languages/types.ts
@@ -1,3 +1,9 @@
-import {type Document, type Node, type Pair} from 'yaml';
+import {type Document, type Node, type Pair, type CST} from 'yaml';
+
+export interface Root {
+  type: 'root';
+  tokens: CST.Token[];
+  contents: Document[];
+}
 
 export type NodeLike = Node | Document | Pair;

--- a/src/languages/yaml-language.ts
+++ b/src/languages/yaml-language.ts
@@ -1,7 +1,7 @@
 import {
-  parseDocument,
+  Parser,
+  Composer,
   type Node,
-  type Document,
   isAlias,
   isDocument,
   isMap,
@@ -17,17 +17,18 @@ import type {
   Language,
   ParseResult,
   OkParseResult,
+  FileError,
   File,
   LanguageContext
 } from '@eslint/core';
-import type {NodeLike} from './types.js';
+import type {NodeLike, Root} from './types.js';
 
 export interface YAMLLanguageOptions {
   [key: PropertyKey]: unknown;
 }
 
-export type YAMLParseResult = ParseResult<Document>;
-export type YAMLOkParseResult = OkParseResult<Document>;
+export type YAMLParseResult = ParseResult<Root>;
+export type YAMLOkParseResult = OkParseResult<Root>;
 
 function getNodeType(node: NodeLike): string {
   if (isAlias(node)) {
@@ -65,7 +66,7 @@ export class YAMLLanguage
     Language<{
       LangOptions: YAMLLanguageOptions;
       Code: YAMLSourceCode;
-      RootNode: Document;
+      RootNode: Root;
       Node: Node;
     }>
 {
@@ -93,6 +94,7 @@ export class YAMLLanguage
    * The visitor keys.
    */
   visitorKeys: Record<string, string[]> = {
+    root: ['contents'],
     document: ['contents'],
     map: ['items'],
     seq: ['items'],
@@ -121,37 +123,53 @@ export class YAMLLanguage
     this.#lineCounter = lineCounter;
 
     try {
-      const root = parseDocument(text, {
-        prettyErrors: true,
+      const parser = new Parser(lineCounter.addNewLine);
+      const composer = new Composer({
         keepSourceTokens: true,
         lineCounter
       });
+      const tokens = [...parser.parse(text)];
+      const docs = [...composer.compose(tokens)];
 
-      if (root.errors.length > 0) {
+      const root: Root = {
+        type: 'root',
+        tokens,
+        contents: docs
+      };
+
+      const errors: FileError[] = [];
+
+      for (const doc of docs) {
+        for (const err of doc.errors) {
+          const linePos = lineCounter.linePos(err.pos[0]);
+          const line = linePos ? linePos.line : 1;
+          const column = linePos ? linePos.col : 1;
+          errors.push({
+            line,
+            column,
+            message: err.message
+          });
+        }
+      }
+
+      if (errors.length > 0) {
         return {
           ok: false,
-          errors: root.errors.map((err) => {
-            const linePos = err.linePos ? err.linePos[0] : undefined;
-            const line = linePos ? linePos.line : 0;
-            const column = linePos ? linePos.col : 0;
-            return {
-              line,
-              column,
-              message: err.message
-            };
-          })
+          errors
         };
       }
 
-      // TODO (43081j): remove this if eslint ever allows node types to be
-      // determined by a language function rather than a node property
-      addNodeType(root);
+      for (const doc of docs) {
+        // TODO (43081j): remove this if eslint ever allows node types to be
+        // determined by a language function rather than a node property
+        addNodeType(doc);
 
-      visit(root, (_key, node) => {
-        if (isNode(node) || isPair(node) || isDocument(node)) {
-          addNodeType(node);
-        }
-      });
+        visit(doc, (_key, node) => {
+          if (isNode(node) || isPair(node) || isDocument(node)) {
+            addNodeType(node);
+          }
+        });
+      }
 
       return {
         ok: true,

--- a/test/languages/__snapshots__/yaml-language_test.ts.snap
+++ b/test/languages/__snapshots__/yaml-language_test.ts.snap
@@ -6,12 +6,7 @@ exports[`YAMLLanguage > parse() > should raise errors 1`] = `
     {
       "column": 1,
       "line": 2,
-      "message": "Map keys must be unique at line 2, column 1:
-
-foo: "bar"
-foo: "bar"
-^
-",
+      "message": "Map keys must be unique",
     },
   ],
   "ok": false,
@@ -24,22 +19,12 @@ exports[`YAMLLanguage > parse() > should raise multiple errors 1`] = `
     {
       "column": 1,
       "line": 2,
-      "message": "Map keys must be unique at line 2, column 1:
-
-foo: "bar"
-foo: "bar"
-^
-",
+      "message": "Map keys must be unique",
     },
     {
       "column": 1,
       "line": 3,
-      "message": "Map keys must be unique at line 3, column 1:
-
-foo: "bar"
-foo: "bar"
-^
-",
+      "message": "Map keys must be unique",
     },
   ],
   "ok": false,

--- a/test/languages/yaml-language_test.ts
+++ b/test/languages/yaml-language_test.ts
@@ -44,8 +44,10 @@ describe('YAMLLanguage', () => {
       );
 
       expect(result.ok).toBe(true);
-      expect(result.ast).instanceOf(Document);
-      expect(result.ast.contents.type).toBe('map');
+      expect(result.ast.type).toBe('root');
+      expect(result.ast.contents.length).toBe(1);
+      expect(result.ast.contents[0]).instanceOf(Document);
+      expect(result.ast.contents[0].contents.type).toBe('map');
     });
 
     it('should raise errors', () => {
@@ -91,8 +93,9 @@ describe('YAMLLanguage', () => {
       );
 
       expect(result.ok).toBe(true);
-      expect(result.ast.type).toBe('document');
-      expect(result.ast.contents.type).toBe('map');
+      expect(result.ast.type).toBe('root');
+      expect(result.ast.contents[0].type).toBe('document');
+      expect(result.ast.contents[0].contents.type).toBe('map');
     });
   });
 

--- a/test/languages/yaml-source-code_test.ts
+++ b/test/languages/yaml-source-code_test.ts
@@ -20,11 +20,12 @@ function getSourceCodeForText(text: string): YAMLSourceCode {
 }
 
 describe('YAMLSourceCode', () => {
-  it('should extract comments on non-documents', () => {
+  it('should extract comments', () => {
     const sourceCode = getSourceCodeForText(
       '# Comment 1\nfoo: bar # Comment 2\nbaz:\n  # Comment 3\n  - boop\n'
     );
     expect(sourceCode.comments).toEqual([
+      {type: 'comment', indent: 0, offset: 0, source: '# Comment 1'},
       {type: 'comment', indent: 2, offset: 40, source: '# Comment 3'},
       {type: 'comment', indent: 0, offset: 21, source: '# Comment 2'}
     ]);


### PR DESCRIPTION
This switches to parsing the CST directly and passing that into the
`Parser` for re-use.

This way we can get hold of all tokens up front rather than relying on
the AST.
